### PR TITLE
Updated private extension and documentation

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -27,7 +27,7 @@ Erweiterungen von Steffen Schultz:
 * [Podcast](https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/podcast/README-de.md): 
   Web-Feed optimiert für die Podcast-Veröffentlichung.
 * [Private](https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/private/README-de.md): 
-  Erstelle passwortgeschützte Seiten.
+  Unterstützung für passwortgeschützte Seiten.
 * [Radioboss](https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/radioboss/README-de.md): 
   Widgets für RadioBoss Cloud.
 * [Random](https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/random/README-de.md): 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Extensions created by Steffen Schultz:
 * [Podcast](https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/podcast): 
   Web feed optimized for podcast publishing.
 * [Private](https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/private): 
-  Create password-protected pages.
+  Support for password-protected pages.
 * [Radioboss](https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/radioboss): 
   Widgets for RadioBoss Cloud.
 * [Random](https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/random): 

--- a/private/README-de.md
+++ b/private/README-de.md
@@ -14,7 +14,7 @@ Zum Deinstallieren lösche einfach die [Erweiterungsdateien](extension.ini).
 
 ## Wie man private Seiten erstellt
 
-Setze `Status: private` und `Password` in den [Einstellungen](https://github.com/datenstrom/yellow-extensions/tree/master/features/core#settings) ganz oben auf der Seite. Die Seite ist dann nicht mehr sichtbar und man muss das Kennwort eingeben um auf den Inhalt zuzugreifen. Man kann eine private Seite weiterhin im [Webbrowser](https://github.com/datenstrom/yellow-extensions/tree/master/features/edit) um im Dateisystem bearbeiten.
+Setze `Status: private` und `Password` in den [Einstellungen](https://github.com/datenstrom/yellow-extensions/tree/master/features/core#settings) ganz oben auf der Seite. Die Seite ist dann nicht mehr sichtbar und man muss das Kennwort eingeben um auf den Inhalt zuzugreifen. Man kann die Seite weiterhin im [Webbrowser](https://github.com/datenstrom/yellow-extensions/tree/master/features/edit) um im Dateisystem bearbeiten.
 
 ## Wie man private Seiten findet
 

--- a/private/README-de.md
+++ b/private/README-de.md
@@ -1,6 +1,6 @@
 Private 0.8.3
-=======================
-Erstelle passwortgeschützte Seiten.
+=============
+Unterstützung für passwortgeschützte Seiten.
 
 <p align="center"><img src="private-screenshot.png?raw=true" alt="Bildschirmfoto"></p>
 
@@ -12,32 +12,38 @@ Erstelle passwortgeschützte Seiten.
 
 Zum Deinstallieren lösche einfach die [Erweiterungsdateien](extension.ini).
 
-## Wie man geschützte Seiten erstellt
+## Wie man private Seiten erstellt
 
-Setze `status: private` und `password: Dein Passwort` in deinen Seiteneinstellungen. 
+Setze `Status: private` und `Password` in den [Einstellungen](https://github.com/datenstrom/yellow-extensions/tree/master/features/core#settings) ganz oben auf der Seite. Die Seite ist dann nicht mehr sichtbar und man muss das Kennwort eingeben um auf den Inhalt zuzugreifen. Man kann eine private Seite weiterhin im [Webbrowser](https://github.com/datenstrom/yellow-extensions/tree/master/features/edit) um im Dateisystem bearbeiten.
 
-**Hinweis**: Bitte verwende diese Erweiterung mit Vorsicht. Sie verschlüsselt keine Daten oder verhindert, dass die Seiten von anderen Erweiterungen ausgelesen werden können. Den Seiten wird lediglich eine einfache Passwortabfrage hinzugefügt. Mittels weiterer Einstellungen kannst du Datenlecks minimieren, siehe hierzu das Beispiel unten. 
+## Wie man private Seiten findet
 
-## Einstellungen
+Du kannst die [Search-Erweiterung](https://github.com/datenstrom/yellow-extensions/tree/master/features/search) verwenden. Sobald du mit deinem Benutzerkonto eingeloggt bist, kannst du nach `status:private` suchen. Das ermöglicht dir alle private Seiten zu finden.
 
-Die folgenden Einstellungen können in der Datei `system/settings/system.ini` vorgenommen werden:
+## Beispiele
 
-`PrivateVisible` = Zeige private Seiten in der Navigation und in Suchergebnissen (Standard: 0)  
-
-## Beispiel
-
-Hier ist eine Beispielseite: 
+Inhaltsdatei with privatem Status: 
 
 ```
 ---
-Title: Geschützte Seite
-Description: Diese Seite ist geschützt. Bitte gib das korrekte Passwort ein, um auf den inhalt zuzugreifen.
+Title: Private Seite
 Status: private
-Password: protected
+Password: password
 ---
-Dies ist eine geschützte Seite. [--more--]
+Diese Seite ist privat. Füge hier weitere Informationen hinzu.
+```
 
-Ein Seitenumbruch wird verwendet, damit Erweiterungen zur Seitenauflistung keine der geschützten Informationen preisgeben können. Die `Description`-Einstellung entfernt ungewollte Informationen aus den Metadaten und kann verwendet werden, um für Besucher eine Meldung anzuzeigen. 
+Inhaltsdatei with privatem Status im Wiki: 
+
+```
+---
+Title: Wiki page
+Layout: wiki
+Tag: Example
+Status: private
+Password: password
+---
+Diese Seite ist privat. Füge hier weitere Informationen hinzu.
 ```
 
 ## Entwickler

--- a/private/README-de.md
+++ b/private/README-de.md
@@ -37,9 +37,9 @@ Inhaltsdatei with privatem Status im Wiki:
 
 ```
 ---
-Title: Wiki page
+Title: Wiki-Seite
 Layout: wiki
-Tag: Example
+Tag: Beispiel
 Status: private
 Password: password
 ---

--- a/private/README.md
+++ b/private/README.md
@@ -14,7 +14,7 @@ To uninstall delete the [extension files](extension.ini).
 
 ## How to make a private page
 
-Set `Status: private` and `Password` in the [settings](https://github.com/datenstrom/yellow-extensions/tree/master/features/core#settings) at the top of a page. The page will no longer be visible and you need enter the password to access the content. You can continue to edit a private page in the [web browser](https://github.com/datenstrom/yellow-extensions/tree/master/features/edit) and the file system.
+Set `Status: private` and `Password` in the [settings](https://github.com/datenstrom/yellow-extensions/tree/master/features/core#settings) at the top of a page. The page will no longer be visible and you need to enter the password to access the content. You can continue to edit the page in the [web browser](https://github.com/datenstrom/yellow-extensions/tree/master/features/edit) and the file system.
 
 ## How to find private pages
 

--- a/private/README.md
+++ b/private/README.md
@@ -1,6 +1,6 @@
 Private 0.8.3
-=======================
-Create password-protected pages.
+=============
+Support for password-protected pages.
 
 <p align="center"><img src="private-screenshot.png?raw=true" alt="Screenshot"></p>
 
@@ -12,32 +12,38 @@ Create password-protected pages.
 
 To uninstall delete the [extension files](extension.ini).
 
-## How to create protected pages
+## How to make a private page
 
-Use `status: private` and `password: your password` in your page settings. 
+Set `Status: private` and `Password` in the [settings](https://github.com/datenstrom/yellow-extensions/tree/master/features/core#settings) at the top of a page. The page will no longer be visible and you need enter the password to access the content. You can continue to edit a private page in the [web browser](https://github.com/datenstrom/yellow-extensions/tree/master/features/edit) and the file system.
 
-**Note**: Please use this extension with caution. It doesn't apply data encryption or protects page content from being parsed by other extensions, the extension only hides the content behind a very basic password form. You can use some page settings to minimize possible data leaks, see example below. 
+## How to find private pages
 
-## Settings
+You can use the [search extension](https://github.com/datenstrom/yellow-extensions/tree/master/features/search). Once you're logged in with your user account, you can search for `status:private`. This allows you to find all private pages. 
 
-The following settings can be configured in file `system/settings/system.ini`:
+## Examples
 
-`PrivateVisible` = Show private pages in navigation and search results (default: 0)  
-
-## Example
-
-Here is an example page: 
+Content file with private status: 
 
 ```
 ---
-Title: Protected page
-Description: This page is protected. Please enter the correct password to access the content.
+Title: Private page
 Status: private
-Password: protected
+Password: password
 ---
-This is a protected page. [--more--]
+This page is private. Add more information here.
+```
 
-We use a page break for the actual protected content so that page listing extensions don't print out any of the protected information. The description setting must be used to remove unwanted content from page metadata, and to write down a short message for visitors. 
+Content file with private status for wiki:
+
+```
+---
+Title: Wiki page
+Layout: wiki
+Tag: Example
+Status: private
+Password: password
+---
+This page is private. Add more information here.
 ```
 
 ## Developer

--- a/private/extension.ini
+++ b/private/extension.ini
@@ -2,7 +2,7 @@
 
 Extension: Private
 Version: 0.8.3
-Description: Create password-protected pages.
+Description: Support for password-protected pages.
 Published: 2019-02-28 16:42:48
 Developer: Steffen Schultz
 

--- a/private/private.php
+++ b/private/private.php
@@ -1,10 +1,10 @@
 <?php
 // Private extension, https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/private
-// Copyright (c) 2018 Steffen Schultz
+// Copyright (c) 2018-2019 Steffen Schultz
 // This file may be used and distributed under the terms of the public license.
 
 class YellowPrivate {
-    const VERSION = "0.8.4";
+    const VERSION = "0.8.5";
     const TYPE = "feature";
     public $yellow;         //access to API
     
@@ -21,16 +21,16 @@ class YellowPrivate {
     // Handle page layout
     public function onParsePageLayout($page, $name) {
         if ($this->yellow->page->get("status")=="private" && $this->yellow->getRequestHandler()=="core") {
-            if (trim($_REQUEST["password"])!==$this->yellow->page->get("password")) {
+            if ($this->yellow->page->isExisting("password") && $this->yellow->page->get("password")==trim($_REQUEST["password"])) {
+                $this->yellow->page->setHeader("Last-Modified", $this->yellow->toolbox->getHttpDateFormatted(time()));
+                $this->yellow->page->setHeader("Cache-Control", "no-cache, must-revalidate");
+            } else {
                 $pageError = "<form class=\"private-form\" action=\"".$this->yellow->page->getLocation(true)."\" method=\"post\">\n";
-                $pageError .= "<p class=\"private-password\"><label for=\"password\">".$this->yellow->text->getHtml("editLoginPassword")."</label><br /><input type=\"password\" class=\"form-control\" name=\"password\" id=\"password\" value=\"".htmlspecialchars($_REQUEST["password"])."\" /></p>\n";
+                $pageError .= "<p class=\"private-password\"><label for=\"password\">".$this->yellow->text->getHtml("editLoginPassword")."</label><br /><input type=\"password\" class=\"form-control\" name=\"password\" id=\"password\" /></p>\n";
                 $pageError .= "<input type=\"submit\" value=\"".$this->yellow->text->getHtml("EditLoginButton")."\" class=\"btn login-btn\" />\n";
                 $pageError .= "</form>\n";
                 $this->yellow->page->error("401", $pageError);
-            } else {
-                $this->yellow->page->set("status", "none");
             }
         }
     }
-
 }


### PR DESCRIPTION
- added cache control, reloading page should re-trigger password form
- removed warning from the documentation, no longer needed for invisible pages
- synced description with draft extension, they are pretty similar now
