### PR TITLE
Added information about cookies

### DIFF
--- a/radioboss/README-de.md
+++ b/radioboss/README-de.md
@@ -29,9 +29,7 @@ Die folgenden Widgets stehen zur Verfügung:
 `links` = Zeigt eine Liste der Streaming-Links.  
 `page` = Zeigt einen Link zur automatisch erstellten Stream-Seite von RadioBoss Cloud an. 
 
-Die Erweiterung verwendet [RadioBoss Cloud](https://www.radioboss.fm/radioboss-cloud/), eine Cloud-basierte Radio-Automationslösung von [DJSoft.net](https://www.djsoft.net). 
-
-*Hinweis*: RadioBoss Cloud befindet sich in stetiger Weiterentwicklung, daher können sich auch die Funktionen der Erweiterung von Zeit zu Zeit verändern. Einige Widgets sind nicht mit allen Browsern kompatibel, und werden es voraussichtlich auch nie sein. Besonders der Internet Explorer hat Probleme mit den verwendeten Javascript-Komponenten.  
+*Hinweis*: [RadioBoss Cloud](https://www.radioboss.fm/radioboss-cloud/) befindet sich in stetiger Weiterentwicklung, daher können sich auch die Funktionen der Erweiterung von Zeit zu Zeit verändern. Einige Widgets sind nicht mit allen Browsern kompatibel, und werden es voraussichtlich auch nie sein. Besonders der Internet Explorer hat Probleme mit den verwendeten Javascript-Komponenten.  
 
 ## Beispiele
 
@@ -95,9 +93,11 @@ Die Server-Konfiguration erhältst du im Reiter Information, nachdem du dich bei
 
 [Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/radioboss.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
+Diese Erweiterung verwendet [RadioBoss Cloud](https://www.radioboss.fm/radioboss-cloud/) von DJSoft. Der Dienstanbieter sammelt personenbezogene Daten und benutzt Cookies.
+
 ## Entwickler
 
-Steffen Schultz mit Code von DJSoft.net. [Hilfe finden](https://github.com/schulle4u/yellow-extensions-schulle4u/issues).
+Steffen Schultz. [Hilfe finden](https://github.com/schulle4u/yellow-extensions-schulle4u/issues).
 
 <p>
 <a href="README-de.md"><img src="https://raw.githubusercontent.com/datenstrom/yellow-extensions/master/source/help/language-de.png" width="15" height="15" alt="Deutsch">&nbsp; Deutsch</a>&nbsp;

--- a/radioboss/README.md
+++ b/radioboss/README.md
@@ -29,9 +29,7 @@ The following widgets are available:
 `links` = Show a list of streaming links.  
 `page` = Displays a link to the auto-generated stream page of RadioBoss Cloud. 
 
-The extension uses [RadioBoss Cloud](https://www.radioboss.fm/radioboss-cloud/), a cloud-based radio automation service developed by [DJSoft.net](https://www.djsoft.net). 
-
-*Note*: RadioBoss Cloud is still under development, therefore things may change also in this extension. Some of the widgets are not compatible with all browsers, and most likely never will be. Especially IE is known to have issues with the involved JS.  
+*Note*: [RadioBoss Cloud](https://www.radioboss.fm/radioboss-cloud/) is still under development, therefore things may change also in this extension. Some of the widgets are not compatible with all browsers, and most likely never will be. Especially IE is known to have issues with the involved JS.  
 
 ## Examples
 
@@ -95,9 +93,11 @@ To obtain your server configuration, log into your RadioBoss cloud account and c
 
 [Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/radioboss.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
+This extension uses [RadioBoss Cloud](https://www.radioboss.fm/radioboss-cloud/) by DJSoft. The service provider collects personal data and uses cookies.
+
 ## Developer
 
-Steffen Schultz featuring DJSoft.net. [Get help](https://github.com/schulle4u/yellow-extensions-schulle4u/issues).
+Steffen Schultz. [Get help](https://github.com/schulle4u/yellow-extensions-schulle4u/issues).
 
 <p>
 <a href="README-de.md"><img src="https://raw.githubusercontent.com/datenstrom/yellow-extensions/master/source/help/language-de.png" width="15" height="15" alt="Deutsch">&nbsp; Deutsch</a>&nbsp;


### PR DESCRIPTION
Some weeks ago [cookie consent was discussed](https://github.com/datenstrom/yellow/discussions/599). Not sure if you need consent for 3rd-party cookies. I think more and more web browsers are blocking them. However, I think it's a good idea to inform people who collects personal data and where you might encounter (tracking) cookies.

I added similar information to all published extensions.