### PR TITLE
Updated audio shortcut, audiostream is obsolete

### DIFF
--- a/audio/README-de.md
+++ b/audio/README-de.md
@@ -1,4 +1,4 @@
-Audio 0.8.7
+Audio 0.8.8
 ===========
 HTML5-Audio-Player.
 
@@ -24,10 +24,6 @@ Eine Audiodatei einbetten:
     [audio /media/downloads/episode-47.mp3 - player2]
     [audio http://wolke.robbenradio.de/podcasts/rt033_yellow.mp3 1]
 
-Du kannst auch Audio-Streams einbetten. Auch wenn die `[audio]`-Abkürzung Streams abspielen kann, existiert die etwas einfachere `[audiostream]`-Abkürzung um seltene Konfigurationsprobleme zu umgehen, z. B. falls  `audioUrlPrefix` verwendet wird: 
-
-    [audiostream http://stream.powerradio4u.de:8000/p4u.mp3 autoplay]
-
 Hier ist eine Seite mit Standalone-Audioplayer:
 
 ```
@@ -36,7 +32,7 @@ Title: Audio
 TitleSlug: audio
 Layout: audio
 ---
-[audiostream http://stream.powerradio4u.de:8000/p4u.mp3 autoplay]
+[audio http://stream.powerradio4u.de:8000/p4u.mp3 autoplay]
 ```
 
 ## Einstellungen

--- a/audio/README.md
+++ b/audio/README.md
@@ -1,4 +1,4 @@
-Audio 0.8.7
+Audio 0.8.8
 ===========
 HTML5 audio player.
 
@@ -24,10 +24,6 @@ Embedding an audio track:
     [audio /media/downloads/episode-47.mp3 - player2]
     [audio http://wolke.robbenradio.de/podcasts/rt033_yellow.mp3 1]
 
-You can also embed audio streams. Although the `[audio]` shortcut is able to play them, a simple `[audiostream]` shortcut is provided to avoid rare configuration problems (e.g. if `audioUrlPrefix` is used): 
-
-    [audiostream http://stream.powerradio4u.de:8000/p4u.mp3]
-
 Here is a page using a standalone audio player:
 
 ```
@@ -36,7 +32,7 @@ Title: Audio
 TitleSlug: audio
 Layout: audio
 ---
-[audiostream http://stream.powerradio4u.de:8000/p4u.mp3 autoplay]
+[audio http://stream.powerradio4u.de:8000/p4u.mp3 autoplay]
 ```
 
 ## Settings

--- a/audio/audio.php
+++ b/audio/audio.php
@@ -4,7 +4,7 @@
 // This file may be used and distributed under the terms of the public license.
 
 class YellowAudio {
-    const VERSION = "0.8.7";
+    const VERSION = "0.8.8";
     public $yellow;            //access to API
     
     // Handle initialisation
@@ -20,9 +20,14 @@ class YellowAudio {
         $output = null;
         if ($name=="audio" && ($type=="block" || $type=="inline")) {
             list($url, $download, $style) = $this->yellow->toolbox->getTextArguments($text);
-            $url = $this->yellow->system->get("audioUrlPrefix").$url;
             if (!preg_match("/^\w+:/", $url)) {
-                $url = $this->yellow->system->get("coreServerBase").$url;
+                $url = $this->yellow->system->get("audioUrlPrefix").$url;
+            }
+            if (!preg_match("/^\w+:/", $url)) {
+                $url = $this->yellow->lookup->normaliseUrl(
+                    $this->yellow->system->get("coreServerScheme"),
+                    $this->yellow->system->get("coreServerAddress"),
+                    $this->yellow->system->get("coreServerBase"), $url);
             } else {
                 $url = $this->yellow->lookup->normaliseUrl("", "", "", $url);
             }
@@ -36,14 +41,7 @@ class YellowAudio {
             $output .="</div>";
         }
         if ($name=="audiostream" && ($type=="block" || $type=="inline")) {
-            list($url, $autoplay, $style) = $this->yellow->toolbox->getTextArguments($text);
-            $url = $this->yellow->lookup->normaliseUrl("", "", "", $url);
-            if (empty($style)) $style = $this->yellow->system->get("audioStyle");
-            $output = "<div class=\"".htmlspecialchars($style)."\">";
-            $output .= "<audio src=\"".htmlspecialchars($url)."\" controls=\"controls\" preload=\"none\"";
-            if ($autoplay) $output .= "autoplay=\"".htmlspecialchars($autoplay)."\"";
-            $output .= ">HTML5 audio not supported.</audio>";
-            $output .="</div>";
+            $page->error(500, "Audiostream is obsolete, it has been replaced by audio shortcut!");
         }
         return $output;
     }


### PR DESCRIPTION
This should simplify things for the user, now there's only one `[audio]` shortcut. The code will not add the optional URL prefix, if the argument in the shortcut is an absolute URL already. Hope this works for you. 