### PR TITLE
Renamed zip to downloads

### DIFF
--- a/antispam/README-de.md
+++ b/antispam/README-de.md
@@ -30,7 +30,7 @@ Linktext anpassen, schließe mehrere Wörter in Anführungszeichen ein:
 
 ## Installation
 
-[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/antispam.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
+[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/antispam.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
 ## Entwickler
 

--- a/antispam/README.md
+++ b/antispam/README.md
@@ -31,7 +31,7 @@ Custom link text, use quotes for multiple words:
 
 ## Installation
 
-[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/antispam.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
+[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/antispam.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
 ## Developer
 

--- a/antispam/extension.ini
+++ b/antispam/extension.ini
@@ -3,7 +3,7 @@
 Extension: Antispam
 Version: 0.8.6
 DocumentationUrl: https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/antispam
-DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/zip/antispam.zip
+DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/downloads/antispam.zip
 Tag: feature, email, antispam
 Description: Alternative email address obfuscator.
 Published: 2021-04-10 10:04:41

--- a/audio/README-de.md
+++ b/audio/README-de.md
@@ -57,7 +57,7 @@ Die folgende Datei kann angepasst werden:
 
 ## Installation
 
-[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/audio.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
+[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/audio.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
 ## Entwickler
 

--- a/audio/README.md
+++ b/audio/README.md
@@ -57,7 +57,7 @@ The following file can be configured:
 
 ## Installation
 
-[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/audio.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
+[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/audio.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
 ## Developer
 

--- a/audio/extension.ini
+++ b/audio/extension.ini
@@ -5,7 +5,7 @@ Version: 0.8.9
 Tag: feature, audio, streaming
 Description: HTML5 audio player.
 DocumentationUrl: https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/audio
-DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/zip/audio.zip
+DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/downloads/audio.zip
 Published: 2021-07-01 18:45:23
 Developer: Steffen Schultz
 system/extensions/audio.php: audio.php, create, update

--- a/codefile/README-de.md
+++ b/codefile/README-de.md
@@ -41,7 +41,7 @@ Verwende eine benutzerdefinierte ID und Dateinamen:
 
 ## Installation
 
-[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/codefile.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
+[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/codefile.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
 Die Javascript-Komponente basiert auf einem Tutorial von [GeeksForGeeks](https://www.geeksforgeeks.org/how-to-trigger-a-file-download-when-clicking-an-html-button-or-javascript/). 
 

--- a/codefile/README.md
+++ b/codefile/README.md
@@ -41,7 +41,7 @@ Use a custom ID and file name:
 
 ## Installation
 
-[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/codefile.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
+[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/codefile.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
 The Javascript component is based on a tutorial from [GeeksForGeeks](https://www.geeksforgeeks.org/how-to-trigger-a-file-download-when-clicking-an-html-button-or-javascript/). 
 

--- a/codefile/extension.ini
+++ b/codefile/extension.ini
@@ -4,7 +4,7 @@ Extension: Codefile
 Version: 0.8.18
 Description: Download code blocks as text file.
 DocumentationUrl: https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/codefile
-DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/zip/codefile.zip
+DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/downloads/codefile.zip
 Published: 2020-11-28 09:39:26
 Developer: Steffen Schultz
 Tag: code, download, feature, file

--- a/csv/README-de.md
+++ b/csv/README-de.md
@@ -54,7 +54,7 @@ Die folgenden Einstellungen können in der Datei `system/extensions/yellow-syste
 
 ## Installation
 
-[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/csv.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
+[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/csv.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
 Die Javascript-Komponente der Erweiterung verwendet Light-table-filter von [Chris Coyier](https://codepen.io/chriscoyier/pen/tIuBL) sowie die [Sort-table-Klasse von Tyler Uebele](https://github.com/stationer/SortTable) freigegeben unter den bedingungen der MIT-Lizenz. 
 

--- a/csv/README.md
+++ b/csv/README.md
@@ -55,7 +55,7 @@ The following settings can be configured in file `system/extensions/yellow-syste
 
 ## Installation
 
-[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/csv.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
+[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/csv.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
 Javascript component includes Light-table-filter by [Chris Coyier](https://codepen.io/chriscoyier/pen/tIuBL), and [Sort-table class by Tyler Uebele](https://github.com/stationer/SortTable) released under the terms of the MIT license. 
 

--- a/csv/extension.ini
+++ b/csv/extension.ini
@@ -5,7 +5,7 @@ Version: 0.8.15
 Tag: feature, csv, data, tables
 Description: CSV file parser.
 DocumentationUrl: https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/csv
-DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/zip/csv.zip
+DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/downloads/csv.zip
 Published: 2022-09-06 18:50:37
 Developer: Steffen Schultz
 system/extensions/csv.php: csv.php, create, update

--- a/daily/README-de.md
+++ b/daily/README-de.md
@@ -49,7 +49,7 @@ Komm' gut in die Woche mit unserer spannenden Weltmusik-Playlist. Jeden Montag u
 
 ## Installation
 
-[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/daily.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
+[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/daily.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
 ## Entwickler
 

--- a/daily/README.md
+++ b/daily/README.md
@@ -49,7 +49,7 @@ Start off the week with our exciting mix of music from all around the world. Tun
 
 ## Installation
 
-[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/daily.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
+[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/daily.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
 ## Developer
 

--- a/daily/extension.ini
+++ b/daily/extension.ini
@@ -5,7 +5,7 @@ Version: 0.8.5
 Tag: feature, page
 Description: Show daily pages.
 DocumentationUrl: https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/daily
-DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/zip/daily.zip
+DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/downloads/daily.zip
 Published: 2020-12-11 12:36:57
 Developer: Steffen Schultz
 system/extensions/daily.php: daily.php, create, update

--- a/include/README-de.md
+++ b/include/README-de.md
@@ -41,7 +41,7 @@ Eine Blogseite einbinden:
 
 ## Installation
 
-[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/include.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
+[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/include.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
 ## Entwickler
 

--- a/include/README.md
+++ b/include/README.md
@@ -41,7 +41,7 @@ Including a blog page:
 
 ## Installation
 
-[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/include.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
+[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/include.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
 ## Developer
 

--- a/include/extension.ini
+++ b/include/extension.ini
@@ -5,7 +5,7 @@ Version: 0.8.5
 Tag: feature, content, page
 Description: Includes page content from other pages.
 DocumentationUrl: https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/include
-DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/zip/include.zip
+DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/downloads/include.zip
 Published: 2021-04-10 10:06:59
 Developer: Steffen Schultz
 system/extensions/include.php: include.php, create, update

--- a/pagesource/README-de.md
+++ b/pagesource/README-de.md
@@ -34,7 +34,7 @@ Die folgenden Einstellungen können in der Datei `system/extensions/yellow-syste
 
 ## Installation
 
-[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/pagesource.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
+[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/pagesource.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
 ## Entwickler
 

--- a/pagesource/README.md
+++ b/pagesource/README.md
@@ -34,7 +34,7 @@ The following settings can be configured in file `system/extensions/yellow-syste
 
 ## Installation
 
-[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/pagesource.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
+[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/pagesource.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
 ## Developer
 

--- a/pagesource/extension.ini
+++ b/pagesource/extension.ini
@@ -4,7 +4,7 @@ Extension: Pagesource
 Version: 0.8.7
 Description: Display Markdown source on pages.
 DocumentationUrl: https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/pagesource
-DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/zip/pagesource.zip
+DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/downloads/pagesource.zip
 Published: 2020-11-28 09:39:26
 Developer: Steffen Schultz
 Tag: feature, markdown, page, source

--- a/podcast/README-de.md
+++ b/podcast/README-de.md
@@ -63,7 +63,7 @@ Des Weiteren können folgende Seiten-Metadaten angegeben werden:
 
 ## Installation
 
-[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/podcast.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
+[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/podcast.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
 Diese Erweiterung basiert auf der originalen [Feed-Erweiterung](https://github.com/datenstrom/yellow-extensions/tree/master/source/feed).
 

--- a/podcast/README.md
+++ b/podcast/README.md
@@ -63,7 +63,7 @@ Additionally, the following page metadata can be specified:
 
 ## Installation
 
-[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/podcast.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
+[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/podcast.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
 Based on the original [feed extension](https://github.com/datenstrom/yellow-extensions/tree/master/source/feed).
 

--- a/podcast/extension.ini
+++ b/podcast/extension.ini
@@ -5,7 +5,7 @@ Version: 0.8.14
 Tag: feature, feed, podcast
 Description: Web feed optimized for podcast publishing.
 DocumentationUrl: https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/podcast
-DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/zip/podcast.zip
+DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/downloads/podcast.zip
 Published: 2022-04-25 16:36:19
 Developer: Steffen Schultz
 system/extensions/podcast.php: podcast.php, create, update

--- a/private/README-de.md
+++ b/private/README-de.md
@@ -76,7 +76,7 @@ Layoutdatei um alle privaten Seiten anzuzeigen:
 
 ## Installation
 
-[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/private.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
+[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/private.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
 ## Entwickler
 

--- a/private/README.md
+++ b/private/README.md
@@ -76,7 +76,7 @@ Layout file for showing all private pages:
 
 ## Installation
 
-[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/private.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
+[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/private.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
 ## Developer
 

--- a/private/extension.ini
+++ b/private/extension.ini
@@ -5,7 +5,7 @@ Version: 0.8.11
 Tag: feature, page, private, security
 Description: Support for password-protected pages.
 DocumentationUrl: https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/private
-DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/zip/private.zip
+DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/downloads/private.zip
 Published: 2022-05-08 11:58:20
 Developer: Steffen Schultz
 system/extensions/private.php: private.php, create, update

--- a/profile/README-de.md
+++ b/profile/README-de.md
@@ -51,7 +51,7 @@ Die folgenden Einstellungen können in der Datei `system/extensions/yellow-syste
 
 ## Installation
 
-[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/profile.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
+[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/profile.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
 ## Entwickler
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -51,7 +51,7 @@ The following settings can be configured in file `system/extensions/yellow-syste
 
 ## Installation
 
-[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/profile.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
+[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/profile.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
 ## Developer
 

--- a/profile/extension.ini
+++ b/profile/extension.ini
@@ -4,7 +4,7 @@ Extension: Profile
 Version: 0.8.9
 Description: Author profile for blog pages.
 DocumentationUrl: https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/profile
-DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/zip/profile.zip
+DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/downloads/profile.zip
 Published: 2022-07-11 10:45:51
 Developer: Steffen Schultz
 Tag: feature, blog, profile

--- a/radioboss/README-de.md
+++ b/radioboss/README-de.md
@@ -94,7 +94,7 @@ Die Server-Konfiguration erhältst du im Reiter Information, nachdem du dich bei
 
 ## Installation
 
-[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/radioboss.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
+[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/radioboss.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
 Diese Erweiterung verwendet [RadioBoss Cloud](https://www.radioboss.fm/radioboss-cloud/) von DJSoft. Der Dienstanbieter sammelt personenbezogene Daten und benutzt Cookies.
 

--- a/radioboss/README.md
+++ b/radioboss/README.md
@@ -94,7 +94,7 @@ To obtain your server configuration, log into your RadioBoss cloud account and c
 
 ## Installation
 
-[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/radioboss.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
+[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/radioboss.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
 This extension uses [RadioBoss Cloud](https://www.radioboss.fm/radioboss-cloud/) by DJSoft. The service provider collects personal data and uses cookies.
 

--- a/radioboss/extension.ini
+++ b/radioboss/extension.ini
@@ -5,7 +5,7 @@ Version: 0.8.10
 Tag: feature, radio, widgets
 Description: Widgets for RadioBoss Cloud.
 DocumentationUrl: https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/radioboss
-DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/zip/radioboss.zip
+DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/downloads/radioboss.zip
 Published: 2021-08-25 15:41:35
 Developer: Steffen Schultz
 system/extensions/radioboss.php: radioboss.php, create, update

--- a/random/README-de.md
+++ b/random/README-de.md
@@ -35,7 +35,7 @@ Zeigt eine zufällige Seite als Anreißertext an:
 
 ## Installation
 
-[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/random.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
+[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/random.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
 ## Entwickler
 

--- a/random/README.md
+++ b/random/README.md
@@ -35,7 +35,7 @@ Show a random page in teaser mode:
 
 ## Installation
 
-[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/random.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
+[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/random.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
 ## Developer
 

--- a/random/extension.ini
+++ b/random/extension.ini
@@ -4,7 +4,7 @@ Extension: Random
 Version: 0.8.7
 Description: Display random pages.
 DocumentationUrl: https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/random
-DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/zip/random.zip
+DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/downloads/random.zip
 Published: 2021-01-07 15:25:44
 Developer: Steffen Schultz
 Tag: feature, pages, random

--- a/readingtime/README-de.md
+++ b/readingtime/README-de.md
@@ -32,7 +32,7 @@ Die folgende Einstellung kann in der Datei `system/extensions/yellow-system.ini`
 
 ## Installation
 
-[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/readingtime.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
+[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/readingtime.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
 ## Entwickler
 

--- a/readingtime/README.md
+++ b/readingtime/README.md
@@ -33,7 +33,7 @@ The following setting can be configured in file `system/extensions/yellow-system
 
 ## Installation
 
-[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/readingtime.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
+[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/readingtime.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
 ## Developer
 

--- a/readingtime/extension.ini
+++ b/readingtime/extension.ini
@@ -5,7 +5,7 @@ Version: 0.8.20
 Tag: feature, page, blog, readingtime
 Description: Show estimated reading time for page content.
 DocumentationUrl: https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/readingtime
-DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/zip/readingtime.zip
+DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/downloads/readingtime.zip
 Published: 2022-07-12 16:00:00
 Developer: Steffen Schultz
 system/extensions/readingtime.php: readingtime.php, create, update

--- a/redirect/README-de.md
+++ b/redirect/README-de.md
@@ -38,7 +38,7 @@ Die folgenden Einstellungen können in der Datei `system/extensions/yellow-syste
 
 ## Installation
 
-[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/redirect.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
+[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/redirect.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
 ## Entwickler
 

--- a/redirect/README.md
+++ b/redirect/README.md
@@ -38,7 +38,7 @@ The following settings can be configured in file `system/extensions/yellow-syste
 
 ## Installation
 
-[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/redirect.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
+[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/redirect.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
 ## Developer
 

--- a/redirect/extension.ini
+++ b/redirect/extension.ini
@@ -5,7 +5,7 @@ Version: 0.8.3
 Tag: feature, page, redirect
 Description: Alternative page redirection.
 DocumentationUrl: https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/redirect
-DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/zip/redirect.zip
+DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/downloads/redirect.zip
 Published: 2021-04-10 10:09:06
 Developer: Steffen Schultz
 system/extensions/redirect.php: redirect.php, create, update

--- a/soundcloud/README-de.md
+++ b/soundcloud/README-de.md
@@ -36,7 +36,7 @@ Die folgenden Einstellungen können in der Datei `system/extensions/yellow-syste
 
 ## Installation
 
-[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/soundcloud.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
+[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/soundcloud.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
 Diese Erweiterung verwendet [Soundcloud](https://soundcloud.com). Der Dienstanbieter sammelt personenbezogene Daten und benutzt Cookies.
 

--- a/soundcloud/README.md
+++ b/soundcloud/README.md
@@ -36,7 +36,7 @@ The following settings can be configured in file `system/extensions/yellow-syste
 
 ## Installation
 
-[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/soundcloud.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
+[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/soundcloud.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
 This extension uses [Soundcloud](https://soundcloud.com). The service provider collects personal data and uses cookies.
 

--- a/soundcloud/extension.ini
+++ b/soundcloud/extension.ini
@@ -4,7 +4,7 @@ Extension: Soundcloud
 Version: 0.8.4
 Description: Embed Soundcloud audio tracks.
 DocumentationUrl: https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/soundcloud
-DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/zip/soundcloud.zip
+DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/downloads/soundcloud.zip
 Published: 2020-07-26 18:07:35
 Developer: Steffen Schultz
 Tag: feature

--- a/spoiler/README-de.md
+++ b/spoiler/README-de.md
@@ -54,7 +54,7 @@ Hier ist weiterer Text.
 
 ## Installation
 
-[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/spoiler.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
+[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/spoiler.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
 ## Entwickler
 

--- a/spoiler/README.md
+++ b/spoiler/README.md
@@ -54,7 +54,7 @@ Here is some more text.
 
 ## Installation
 
-[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/spoiler.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
+[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/spoiler.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
 ## Developer
 

--- a/spoiler/extension.ini
+++ b/spoiler/extension.ini
@@ -5,7 +5,7 @@ Version: 0.8.7
 Tag: feature, page, spoiler
 Description: Hide certain page elements.
 DocumentationUrl: https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/spoiler
-DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/zip/spoiler.zip
+DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/downloads/spoiler.zip
 Published: 2021-04-10 10:09:45
 Developer: Steffen Schultz
 system/extensions/spoiler.php: spoiler.php, create, update

--- a/ticker/README-de.md
+++ b/ticker/README-de.md
@@ -35,7 +35,7 @@ Die folgenden Einstellungen können in der Datei `system/extensions/yellow-syste
 
 ## Installation
 
-[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/ticker.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
+[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/ticker.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
 [SimplePie parser 1.5](http://simplepie.org/) von Ryan Parman, Geoffrey Sneddon, Ryan McCue und Beitragende, freigegeben unter den Bedingungen der [BSD-Lizenz](http://www.opensource.org/licenses/BSD-3-Clause). 
 

--- a/ticker/README.md
+++ b/ticker/README.md
@@ -35,7 +35,7 @@ The following settings can be configured in file `system/extensions/yellow-syste
 
 ## Installation
 
-[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/ticker.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
+[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/ticker.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
 [SimplePie parser 1.5](http://simplepie.org/) by Ryan Parman, Geoffrey Sneddon, Ryan McCue and contributors. It's licensed under [BSD license](http://www.opensource.org/licenses/BSD-3-Clause). 
 

--- a/ticker/extension.ini
+++ b/ticker/extension.ini
@@ -4,7 +4,7 @@ Extension: Ticker
 Version: 0.8.10
 Description: RSS feed parser.
 DocumentationUrl: https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/ticker
-DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/zip/ticker.zip
+DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/downloads/ticker.zip
 Published: 2020-11-28 12:12:06
 Developer: Steffen Schultz
 Tag: feature, feed, rss, simplepie

--- a/twitter/README-de.md
+++ b/twitter/README-de.md
@@ -50,7 +50,7 @@ Die folgenden Einstellungen können in der Datei `system/extensions/yellow-syste
 
 ## Installation
 
-[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/twitter.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
+[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/twitter.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
 Diese Erweiterung verwendet [Twitter](https://www.twitter.com). Der Dienstanbieter sammelt personenbezogene Daten und benutzt Cookies.
 

--- a/twitter/README.md
+++ b/twitter/README.md
@@ -50,7 +50,7 @@ The following settings can be configured in file `system/extensions/yellow-syste
 
 ## Installation
 
-[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/twitter.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
+[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/twitter.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
 This extension uses [Twitter](https://www.twitter.com). The service provider collects personal data and uses cookies.
 

--- a/twitter/extension.ini
+++ b/twitter/extension.ini
@@ -4,7 +4,7 @@ Extension: Twitter
 Version: 0.8.6
 Description: Embed Twitter messages.
 DocumentationUrl: https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/twitter
-DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/zip/twitter.zip
+DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/downloads/twitter.zip
 Published: 2021-05-29 10:26:47
 Developer: Steffen Schultz
 Tag: feature

--- a/wittstock/README-de.md
+++ b/wittstock/README-de.md
@@ -12,7 +12,7 @@ Alle Themendateien befinden sich im `system/themes`-Verzeichnis. Alle Layoutdate
 
 ## Installation
 
-[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/zip/wittstock.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
+[Erweiterung herunterladen](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/wittstock.zip) und die Zip-Datei in dein `system/extensions`-Verzeichnis kopieren. Rechtsklick bei Safari.
 
 Diese Erweiterung benutzt [Simple.css 2.1.1](https://github.com/kevquirk/simple.css) von Kev Quirk. 
 

--- a/wittstock/README.md
+++ b/wittstock/README.md
@@ -12,7 +12,7 @@ All theme files are stored in your `system/themes` folder. All layout files are 
 
 ## Installation
 
-[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/zip/wittstock.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
+[Download extension](https://github.com/datenstrom/yellow-extensions/raw/master/downloads/wittstock.zip) and copy zip file into your `system/extensions` folder. Right click if you use Safari.
 
 This extension uses [Simple.css 2.1.1](https://github.com/kevquirk/simple.css) by Kev Quirk. 
 

--- a/wittstock/extension.ini
+++ b/wittstock/extension.ini
@@ -4,7 +4,7 @@ Extension: Wittstock
 Version: 0.8.21
 Description: Wittstock is a classless theme for Datenstrom Yellow.
 DocumentationUrl: https://github.com/schulle4u/yellow-extensions-schulle4u/tree/master/wittstock
-DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/zip/wittstock.zip
+DownloadUrl: https://github.com/datenstrom/yellow-extensions/raw/master/downloads/wittstock.zip
 Published: 2022-09-06 12:32:54
 Designer: Steffen Schultz
 Tag: classless, theme


### PR DESCRIPTION
I renamed zip to downloads in `datenstrom/yellow-extensions`, here is the corresponding change for your repository. Now they should be back in sync.